### PR TITLE
fix: reset topicsData in store when sorting by newest/oldest.

### DIFF
--- a/src/components/TopicList.vue
+++ b/src/components/TopicList.vue
@@ -28,6 +28,7 @@ const activeSort = ref('')
 const sort = (sortName) => {
   isLoading.value = true
   activeSort.value = sortName
+  topicsStore.clearTopicsData()
   topicsStore
     .getTopicsData({
       sort: sortName,

--- a/src/stores/useTopicsStore.js
+++ b/src/stores/useTopicsStore.js
@@ -28,6 +28,10 @@ export const useTopicsStore = defineStore('useTopicsStore', () => {
       console.log(error)
     }
   }
+  // 清空 topics api 資料
+  const clearTopicsData = () => {
+    topicsData.value = []
+  }
 
-  return { topicsData, getTopicsData, pageNum, sortSelect, limitNum, keywordString }
+  return { topicsData, getTopicsData, pageNum, sortSelect, limitNum, keywordString, clearTopicsData }
 })


### PR DESCRIPTION
## Summary

點擊“最新“、”最舊“時清空store裡的topicsData資料
<img width="1280" alt="截圖 2025-02-12 下午4 52 34" src="https://github.com/user-attachments/assets/afe0c771-fbb2-4830-ba21-291f6cafb4b1" />


## How to Test

npm run dev
http://localhost:5173/USphere/