### PR TITLE
fix: set text limits and ellipsis for topic title and content.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "usphere",
       "version": "0.0.0",
       "dependencies": {
+        "@tailwindcss/line-clamp": "^0.4.4",
         "axios": "^1.7.9",
         "dayjs": "^1.11.13",
         "pinia": "^2.2.6",
@@ -1448,6 +1449,14 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "usphere",
       "version": "0.0.0",
       "dependencies": {
-        "@tailwindcss/line-clamp": "^0.4.4",
         "axios": "^1.7.9",
         "dayjs": "^1.11.13",
         "pinia": "^2.2.6",
@@ -21,6 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.14.0",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@vitejs/plugin-vue": "^5.1.4",
         "@vue/eslint-config-prettier": "^10.1.0",
         "autoprefixer": "^10.4.20",
@@ -1454,6 +1454,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
       "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "dev": true,
       "peerDependencies": {
         "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "deploy": "vite build && gh-pages -d dist"
   },
   "dependencies": {
-    "@tailwindcss/line-clamp": "^0.4.4",
     "axios": "^1.7.9",
     "dayjs": "^1.11.13",
     "pinia": "^2.2.6",
@@ -25,6 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@vitejs/plugin-vue": "^5.1.4",
     "@vue/eslint-config-prettier": "^10.1.0",
     "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "deploy": "vite build && gh-pages -d dist"
   },
   "dependencies": {
+    "@tailwindcss/line-clamp": "^0.4.4",
     "axios": "^1.7.9",
     "dayjs": "^1.11.13",
     "pinia": "^2.2.6",

--- a/src/components/BreadcrumbNav.vue
+++ b/src/components/BreadcrumbNav.vue
@@ -9,9 +9,16 @@ const props = defineProps({
 </script>
 
 <template>
-  <section class="mb-5">
-    <ul class="text-sm text-gray-450 py-5px me-5 flex">
-      <li v-for="(item, idx) in props.breadcrumbs" :key="idx">
+  <section class="w-full mb-5">
+    <ul class="text-sm text-gray-450 py-5px flex truncate">
+      <!-- 如果是最後一項，添加 truncate w-full -->
+      <li
+        v-for="(item, idx) in props.breadcrumbs"
+        :key="idx"
+        :class="{
+          'truncate w-full': idx === breadcrumbs.length - 1,
+        }"
+      >
         <RouterLink
           v-if="item.path"
           :to="item.path"

--- a/src/components/HotTopicsList.vue
+++ b/src/components/HotTopicsList.vue
@@ -29,11 +29,12 @@ onMounted(() => {
     <h3 class="text-sm font-bold">熱門話題</h3>
     <ul>
       <li
-        v-for="topic in popularStore.popularTopicsData"
+        v-for="(topic, idx) in popularStore.popularTopicsData"
         :key="topic.id"
-        class="text-sm font-medium pt-5 pb-3 border-b hover:text-primary-blue"
+        class="text-sm font-medium pt-5 pb-3 hover:text-primary-blue line-clamp-2"
+        :class="{ 'border-b border-gray-250': idx !== popularStore.popularTopicsData.length - 1 }"
       >
-        <RouterLink :to="{ name: 'topicDetail', params: { id: topic.id } }">{{
+        <RouterLink :to="{ name: 'topicDetail', params: { id: topic.id } }" class="line-clamp-2">{{
           topic.title
         }}</RouterLink>
       </li>

--- a/src/components/TopicList.vue
+++ b/src/components/TopicList.vue
@@ -111,7 +111,7 @@ onMounted(() => {
           <!-- 管理貼文 -->
           <TopicMenuButton :topicData="topic" @click="addData(topic)" />
         </div>
-        <p class="text-lg font-semibold mb-3">{{ topic.title }}</p>
+        <p class="text-lg font-semibold mb-3 truncate">{{ topic.title }}</p>
         <p class="text-base leading-6.5 text-gray-450 mb-3 truncate">{{ topic.content }}</p>
         <div class="mb-3">
           <small v-for="item in topic.tags" :key="item" class="text-sm text-gray-450 me-3"

--- a/src/stores/useLoginUser.js
+++ b/src/stores/useLoginUser.js
@@ -4,7 +4,7 @@ import { defineStore } from 'pinia'
 export const useLoginUser = defineStore('useLoginUser', () => {
   // 預設名稱與頭像
   const defaltName = '匿名使用者'
-  const defaltPic = '/USphere/src/assets/member.png'
+  const defaltPic = '/USphere/src/assets/avatarDefault.png'
 
   // 儲存使用者資訊
   const userInfo = ref({

--- a/src/views/AddTopicView.vue
+++ b/src/views/AddTopicView.vue
@@ -37,21 +37,22 @@ const tempTopicTitle = ref('')
 const tempTopicContent = ref('')
 
 const canPublish = () =>
-  tempTopicContent.value <= contentMaxLength && tempTopicTitle.value <= titleMaxLength
+  tempTopicContent.value <= contentMaxLength && tempTopicTitle.value.length <= titleMaxLength
 const isSubmit = ref(false)
 
+// 字數計算方法
+const calculateCharCount = (text) => {
+  const chineseFullCharCount = (text.match(/[\u2e80-\u9fff\uff00-\uffef]/g) || []).length
+  const englishHalfCharCount = text.length - chineseFullCharCount
+  return chineseFullCharCount * 2 + englishHalfCharCount
+}
 // 標題字數計算
 watch(tempTopicTitle, (newVal) => {
-  const chineseFullCharCount = (newVal.match(/[\u2e80-\u9fff\uff00-\uffef]/g) || []).length
-  const englishHalfCharCount = newVal.length - chineseFullCharCount
-  titleCharCount.value = chineseFullCharCount * 2 + englishHalfCharCount
+  titleCharCount.value = calculateCharCount(newVal)
 })
-
 // 內文字數計算
 watch(tempTopicContent, (newVal) => {
-  const chineseFullCharCount = (newVal.match(/[\u2e80-\u9fff\uff00-\uffef]/g) || []).length
-  const englishHalfCharCount = newVal.length - chineseFullCharCount
-  contentCharCount.value = chineseFullCharCount * 2 + englishHalfCharCount
+  contentCharCount.value = calculateCharCount(newVal)
 })
 
 // 點擊'忍痛放棄'

--- a/src/views/AddTopicView.vue
+++ b/src/views/AddTopicView.vue
@@ -37,7 +37,7 @@ const tempTopicTitle = ref('')
 const tempTopicContent = ref('')
 
 const canPublish = () =>
-  tempTopicContent.value <= contentMaxLength && tempTopicTitle.value.length <= titleMaxLength
+  tempTopicContent.value.length <= contentMaxLength && tempTopicTitle.value.length <= titleMaxLength
 const isSubmit = ref(false)
 
 // 字數計算方法

--- a/src/views/TopicDetailView.vue
+++ b/src/views/TopicDetailView.vue
@@ -38,7 +38,7 @@ const handleNavigate = () => {
 
 <template>
   <main class="container container-customizing-1060 flex justify-between gap-5 my-[30px]">
-    <div class="w-full">
+    <div style="width: 790px">
       <BreadcrumbNav :breadcrumbs="breadcrumbData" />
       <TopicDetailCard @update-data="handleTitleUpdate" />
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 import colors from 'tailwindcss/colors'
 import scrollbarHide from 'tailwind-scrollbar-hide'
+import lineClamp from '@tailwindcss/line-clamp'
 
 export default {
   content: [
@@ -61,5 +62,6 @@ export default {
   },
   plugins: [
     scrollbarHide,
+    lineClamp,
   ],
 }


### PR DESCRIPTION
## Summary

1. 話題的標題及內文的字數限制設定：標題限制50字元、內文限制600字元
2. 話題詳情頁的麵包屑名稱顯示字數設定：超過一行後面省略變...
3. 首頁話題列表的主標顯示字數設定：超過一行後面省略變...
4. 熱門話題列表的主標顯示字數設定：超過二行後面省略變...

<img width="1280" alt="截圖 2025-02-20 下午5 14 17" src="https://github.com/user-attachments/assets/ee258d5f-7a6d-4e77-a018-6eaee345b5ac" />
<img width="1280" alt="截圖 2025-02-20 下午5 14 49" src="https://github.com/user-attachments/assets/472e961c-aae5-45b9-952e-fb554816e2c0" />
<img width="1280" alt="截圖 2025-02-20 下午5 18 53" src="https://github.com/user-attachments/assets/405fa56d-8537-4fec-a227-257d9796d487" />


## How to Test

npm run dev
http://localhost:5173/USphere/
http://localhost:5173/USphere/topics/3939b1fd-7e49-45ed-9236-f7ceba26d1bc
http://localhost:5173/USphere/add-topic