### PR TITLE
fix: update comment timestamp to show creation time and adjust UTC ha…

### DIFF
--- a/src/components/CommentCard.vue
+++ b/src/components/CommentCard.vue
@@ -90,7 +90,7 @@ const postLike = async (id, type) => {
         <!-- 留言者名稱、時間 -->
         <div class="flex mb-2">
           <p class="text-sm font-medium me-3">{{ comment.user_name }}</p>
-          <time class="text-sm text-gray-450">{{ timeToNow(comment.updated_at) }}</time>
+          <time class="text-sm text-gray-450">{{ timeToNow(comment.created_at) }}</time>
         </div>
         <!-- 留言內容 -->
         <p class="text-sm text-gray-650 mb-2 break-words whitespace-pre-wrap truncate text-wrap">

--- a/src/time.js
+++ b/src/time.js
@@ -8,7 +8,7 @@ dayjs.extend(relativeTime)
 // 到現在為止的時間
 const timeToNow = (time) => {
   // 設定本地時間為 UTC 時間（因為後端資料庫設定為 UTC 時間）
-  return dayjs(time).utc(true).toNow(true)
+  return dayjs.utc(time).toNow(true)
 }
 
 export default timeToNow


### PR DESCRIPTION
## Summary

1. 修正 time.js 的 UTC 設定
2. comment 的時間顯示調整成 created_at 屬性
![截圖 2025-03-13 下午5 23 20](https://github.com/user-attachments/assets/1df0e47c-648b-445b-8685-da9229821a7d)


## How to Test

npm run dev
首頁及話題詳情頁