### PR TITLE
Feat/mobile home page

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="container mt-auto">
+  <footer class="hidden sm:block container">
     <p class="text-center text-xs text-gray-450 pb-4 pt-8">Copyright © 2025 出芽工作室</p>
   </footer>
 </template>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -96,7 +96,9 @@ watch(
 </script>
 
 <template>
-  <header class="bg-white border-b border-gray-250 pt-7 pb-6 sm:py-5">
+  <header
+    class="fixed top-0 left-0 w-full z-50 bg-white border-b border-gray-250 pt-7 pb-6 sm:py-5"
+  >
     <div class="container grid grid-cols-4 gap-6 sm:gap-5 items-center relative">
       <!-- logo -->
       <RouterLink
@@ -143,7 +145,10 @@ watch(
         class="absolute top-0 right-6 sm:static sm:top-auto sm:right-auto sm:col-span-1 flex flex-row-reverse sm:flex-row justify-start sm:justify-end items-center gap-2"
       >
         <!-- 系統通知 -->
-        <RouterLink class="bell-icon relative w-10 h-10 hidden sm:flex justify-center items-center">
+        <RouterLink
+          to="/avatar"
+          class="bell-icon relative w-10 h-10 hidden sm:flex justify-center items-center"
+        >
           <img alt="bellIcon" class="w-6 h-6 block" src="@/assets/bellIcon.svg" />
         </RouterLink>
         <!-- 會員 -->

--- a/src/components/HotTopicQuickAdd.vue
+++ b/src/components/HotTopicQuickAdd.vue
@@ -24,7 +24,16 @@ function handleAbandonClick() {
 </script>
 
 <template>
-  <div class="border rounded border-gray-250 bg-white p-5 mb-8">
+  <div class="fixed bottom-11 right-6 sm:hidden rounded-full bg-primary-blue p-1">
+    <button
+      type="button"
+      @click="handleAbandonClick"
+      class="w-9 h-9 text-[36px] leading-none text-white text-center align-middle"
+    >
+      ＋
+    </button>
+  </div>
+  <div class="hidden sm:block border rounded border-gray-250 bg-white p-5 mb-8">
     <h2 class="text-lg font-extrabold leading-6 mb-4">USphere<br />這是屬於我們的圈子</h2>
     <p class="text-base leading-6 text-gray-350 mb-4">快來發起新話題，加入我們的圈子吧！</p>
     <button

--- a/src/components/TopicList.vue
+++ b/src/components/TopicList.vue
@@ -73,7 +73,9 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="mb-5">
+  <div
+    class="py-5 sm:pt-[30px] px-6 sm:px-0 fixed top-[159px] left-0 w-full bg-primary-bg z-40 sm:static sm:top-auto sm:left-auto sm:w-auto"
+  >
     <button
       @click="sort('newest')"
       type="button"
@@ -95,94 +97,100 @@ onMounted(() => {
       最舊
     </button>
   </div>
-  <ul class="flex flex-col">
-    <li
-      v-for="topic in topicsStore.topicsData"
-      :key="topic.id"
-      class="border rounded border-gray-250 bg-white p-5 mb-5 w-full relative"
-    >
-      <RouterLink
-        :to="{ name: 'topicDetail', params: { id: topic.id } }"
-        class="absolute inset-0"
-      />
-      <div class="flex mb-[18px]">
-        <img
-          :src="topic.author_pic"
-          alt="User Avatar"
-          class="w-9 h-9 object-cover rounded-full me-2"
+  <div
+    class="max-h-none h-[calc(100vh_-_290px)] sm:max-h-[calc(100vh_-_41px)] overflow-y-auto mt-[71px] sm:mt-0"
+  >
+    <ul class="flex flex-col">
+      <li
+        v-for="topic in topicsStore.topicsData"
+        :key="topic.id"
+        class="border-t border-b sm:border sm:rounded border-gray-250 bg-white py-5 px-6 sm:p-5 mb-2 sm:mb-5 w-full relative"
+      >
+        <RouterLink
+          :to="{ name: 'topicDetail', params: { id: topic.id } }"
+          class="absolute inset-0"
         />
-        <div class="flex flex-col justify-between">
-          <p class="text-sm leading-4 font-medium">{{ topic.author }}</p>
-          <time class="text-xs text-gray-450">{{ timeToNow(topic.created_at) }}</time>
-        </div>
-        <!-- 管理貼文 -->
-        <TopicMenuButton :topicData="topic" @click="addData(topic)" />
-      </div>
-      <p class="text-lg font-semibold mb-3 truncate">{{ topic.title }}</p>
-      <p class="text-base leading-6.5 text-gray-450 mb-3 truncate">{{ topic.content }}</p>
-      <div class="mb-3">
-        <small v-for="item in topic.tags" :key="item" class="text-sm text-gray-450 me-3"
-          >#{{ item }}</small
-        >
-      </div>
-      <!-- icon -->
-      <div class="flex items-center gap-4">
-        <div class="flex items-center">
-          <button
-            type="button"
-            @click.stop.prevent="managentTopic('回覆')"
-            class="w-5 h-5 me-1 rounded-full z-10"
-          >
-            <img src="../assets/TopicCommentIcon.svg" alt="讚" class="w-full h-full" />
-          </button>
-          <p class="text-sm font-medium">{{ topic.comments }}</p>
-        </div>
-        <div class="flex items-center">
-          <button
-            type="button"
-            @click.stop.prevent="managentTopic('讚')"
-            class="w-5 h-5 me-1 rounded-full z-10"
-          >
-            <img src="../assets/TopicLikeIcon.svg" alt="讚" class="w-full h-full" />
-          </button>
-          <p class="text-sm font-medium">{{ topic.likes }}</p>
-        </div>
-      </div>
-    </li>
-  </ul>
-  <!-- loading UI -->
-  <ul v-if="isLoading" class="animate-pulse flex flex-col">
-    <li
-      v-for="item in 3"
-      :key="item"
-      class="border rounded border-gray-250 bg-white p-5 mb-5 w-full"
-    >
-      <div class="flex mb-[18px]">
-        <svg
-          class="w-9 h-9 me-2 text-gray-200"
-          aria-hidden="true"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            d="M10 0a10 10 0 1 0 10 10A10.011 10.011 0 0 0 10 0Zm0 5a3 3 0 1 1 0 6 3 3 0 0 1 0-6Zm0 13a8.949 8.949 0 0 1-4.951-1.488A3.987 3.987 0 0 1 9 13h2a3.987 3.987 0 0 1 3.951 3.512A8.949 8.949 0 0 1 10 18Z"
+        <div class="flex mb-[18px]">
+          <img
+            :src="topic.author_pic"
+            alt="User Avatar"
+            class="w-9 h-9 object-cover rounded-full me-3 sm:me-2"
           />
-        </svg>
-        <div class="flex flex-col justify-between">
-          <div class="w-16 h-3.5 bg-gray-200 rounded-full"></div>
-          <div class="w-12 h-3 bg-gray-200 rounded-full"></div>
+          <div class="flex flex-col justify-between">
+            <p class="text-sm leading-4 font-medium">{{ topic.author }}</p>
+            <time class="text-xs text-gray-450">{{ timeToNow(topic.created_at) }}</time>
+          </div>
+          <!-- 管理貼文 -->
+          <TopicMenuButton :topicData="topic" @click="addData(topic)" />
         </div>
-      </div>
-      <div class="flex flex-col gap-3">
-        <div class="bg-gray-200 h-[18px] w-48 rounded-full"></div>
-        <div class="bg-gray-200 h-4 w-full rounded-full"></div>
-        <div class="bg-gray-200 h-4 w-full rounded-full"></div>
-        <div class="bg-gray-200 h-4 w-3/4 rounded-full"></div>
-      </div>
-    </li>
-  </ul>
-  <button @click="more" type="button" class="block mx-auto mt-1 text-xs text-primary-blue">
+        <p class="test-base sm:text-lg font-semibold mb-5 sm:mb-3 sm:truncate">{{ topic.title }}</p>
+        <p class="text-sm sm:text-base sm:leading-6.5 text-gray-450 mb-4 sm:mb-3 truncate">
+          {{ topic.content }}
+        </p>
+        <div class="mb-4 sm:mb-3">
+          <small v-for="item in topic.tags" :key="item" class="text-sm text-gray-450 me-3"
+            >#{{ item }}</small
+          >
+        </div>
+        <!-- icon -->
+        <div class="flex items-center gap-4">
+          <div class="flex items-center">
+            <button
+              type="button"
+              @click.stop.prevent="managentTopic('回覆')"
+              class="w-[18px] sm:w-5 h-[18px] sm:h-5 me-1 rounded-full z-10"
+            >
+              <img src="../assets/TopicCommentIcon.svg" alt="讚" class="w-full h-full" />
+            </button>
+            <p class="text-sm font-medium">{{ topic.comments }}</p>
+          </div>
+          <div class="flex items-center">
+            <button
+              type="button"
+              @click.stop.prevent="managentTopic('讚')"
+              class="w-[18px] sm:w-5 h-[18px] sm:h-5 me-1 rounded-full z-10"
+            >
+              <img src="../assets/TopicLikeIcon.svg" alt="讚" class="w-full h-full" />
+            </button>
+            <p class="text-sm font-medium">{{ topic.likes }}</p>
+          </div>
+        </div>
+      </li>
+    </ul>
+    <!-- loading UI -->
+    <ul v-if="isLoading" class="animate-pulse flex flex-col">
+      <li
+        v-for="item in 3"
+        :key="item"
+        class="border rounded border-gray-250 bg-white p-5 mb-5 w-full"
+      >
+        <div class="flex mb-[18px]">
+          <svg
+            class="w-9 h-9 me-2 text-gray-200"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              d="M10 0a10 10 0 1 0 10 10A10.011 10.011 0 0 0 10 0Zm0 5a3 3 0 1 1 0 6 3 3 0 0 1 0-6Zm0 13a8.949 8.949 0 0 1-4.951-1.488A3.987 3.987 0 0 1 9 13h2a3.987 3.987 0 0 1 3.951 3.512A8.949 8.949 0 0 1 10 18Z"
+            />
+          </svg>
+          <div class="flex flex-col justify-between">
+            <div class="w-16 h-3.5 bg-gray-200 rounded-full"></div>
+            <div class="w-12 h-3 bg-gray-200 rounded-full"></div>
+          </div>
+        </div>
+        <div class="flex flex-col gap-3">
+          <div class="bg-gray-200 h-[18px] w-48 rounded-full"></div>
+          <div class="bg-gray-200 h-4 w-full rounded-full"></div>
+          <div class="bg-gray-200 h-4 w-full rounded-full"></div>
+          <div class="bg-gray-200 h-4 w-3/4 rounded-full"></div>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <button @click="more" type="button" class="block mx-auto mt-3 text-xs text-primary-blue">
     載入更多話題
   </button>
 </template>

--- a/src/components/TopicList.vue
+++ b/src/components/TopicList.vue
@@ -123,7 +123,7 @@ onMounted(() => {
           <!-- 管理貼文 -->
           <TopicMenuButton :topicData="topic" @click="addData(topic)" />
         </div>
-        <p class="test-base sm:text-lg font-semibold mb-5 sm:mb-3 sm:truncate">{{ topic.title }}</p>
+        <p class="text-base sm:text-lg font-semibold mb-5 sm:mb-3 sm:truncate">{{ topic.title }}</p>
         <p class="text-sm sm:text-base sm:leading-6.5 text-gray-450 mb-4 sm:mb-3 truncate">
           {{ topic.content }}
         </p>

--- a/src/components/TopicMenuButton.vue
+++ b/src/components/TopicMenuButton.vue
@@ -33,7 +33,7 @@ onClickOutside(menuRef, () => {
 <template>
   <div class="ms-auto relative">
     <!-- menu 按鈕 -->
-    <button type="button" class="w-5 h-5" @click.stop.prevent="toggleMenu">
+    <button type="button" class="w-[18px] sm:w-5 h-[18px] sm:h-5" @click.stop.prevent="toggleMenu">
       <img src="../assets/moreIcon.svg" alt="管理" class="w-full h-full" />
     </button>
     <!-- 菜單選項 -->

--- a/src/views/AddTopicView.vue
+++ b/src/views/AddTopicView.vue
@@ -334,7 +334,7 @@ watch(
       </div>
     </div>
     <div class="col-span-1">
-      <HotTopicQuickAdd @navigate="handleNavigate" />
+      <HotTopicQuickAdd @navigate="handleNavigate" v-if="route.query.id" />
       <HotTopicsList />
     </div>
     <!-- 彈窗 -->

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -28,14 +28,18 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <main class="container grid grid-cols-4 gap-5 my-[30px]">
-    <div class="col-span-1">
+  <main
+    class="relative container grid grid-cols-1 sm:grid-cols-5 md:grid-cols-4 gap-5 sm:pb-[30px]"
+  >
+    <div class="hidden md:block sm:col-span-1 pt-[159px] sm:pt-[121px]">
       <MembershipPromo />
     </div>
-    <div class="col-span-2">
+    <div
+      class="relative w-[calc(100%_+_3rem)] left-[-1.5rem] sm:w-full sm:left-0 sm:col-span-3 md:col-span-2 pt-[159px] sm:pt-[91px]"
+    >
       <TopicList />
     </div>
-    <div class="col-span-1">
+    <div class="hidden sm:block sm:col-span-2 md:col-span-1 pt-[159px] sm:pt-[121px]">
       <HotTopicQuickAdd @navigate="handleNavigate" />
       <HotTopicsList />
     </div>


### PR DESCRIPTION
## Summary

新增 響應式首頁：
- 平版以下 隱藏升級會員卡片
- m 版 隱藏熱門話題卡片（m 版熱門按鈕樣式及功能待後續開新分支處理）
- m 版 隱藏 footer
- m 版 topic list 樣式
- topic list 顯示方式改 scroll（scroll 載入更多功能待後續開新分支處理）
<img width="744" alt="image" src="https://github.com/user-attachments/assets/59f7664b-dc00-4558-8b66-c055e2d0920a" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/51a3c162-fbed-4b26-b285-7f421387136f" />


## How to Test

npm run dev